### PR TITLE
fix(build): handled err in copyDirRecursively()

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -75,6 +75,9 @@ func copyFile(src string, d fs.DirEntry, dest string) error {
 
 func copyDirRecursively(src string, dst string) error {
 	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 		outpath := dst + strings.TrimPrefix(path, src)
 		return copyFile(path, d, outpath)
 	})


### PR DESCRIPTION
*related issue*: https://github.com/dannyvankooten/gozer/issues/4

Adds an `err != nil` check in the callback function passed to `filepath.WalkDir()`. This callback is of type [WalkDirFunc](https://pkg.go.dev/io/fs#WalkDirFunc) which receives an err value. This err will be non-nil in two cases:
* The `path` argument does not exist in the file system
   * This case was encountered in the above issue where `public/` was deleted
* The program cannot read the `path` file/dir
   * This case can be observed if we change the read permissions of `public/`

The `gozer build` logs will print the following for these respective cases with this change:
```
2024/02/25 15:10:29 [FATAL] Error copying public/ directory: [lstat public: no such file or directory]
```
```
2024/02/25 15:10:48 [FATAL] Error copying public/ directory: [open public: permission denied]
```
