### PR TITLE
Feed changes, new Content function and minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Options in `config.toml`:
 [[feeds]]
 title = "Blog"
 path = "content/"
+filename = "myfeed.xml" # optional
 length = 10 # 0 = no limit
 ```
 

--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ To show a list of the 5 most recent posts:
 
 ## Config
 
-`config.toml`
+Options in `config.toml`:
 
-`url`: Website base URL  
-`title`: Website title
+`url`: Website base URL
 
-`feeds`:
+`title`: Website title (used if no page title given)
 
+`feeds`:  
 ```
 [[feeds]]
 title = "Blog"
@@ -160,8 +160,31 @@ length = 10 # 0 = no limit
 
 ## Functions
 
-`HasPrefix` - `HasPrefix *string* *prefix*`  
+`HasPrefix`: `HasPrefix *string* *prefix*`
 
+`HasSuffix`: `HasSuffix *string* *suffix*`
+
+`Contains`: `Contains *string* *sub_string*`
+
+`Replace`: `Replace *string* *target* *replacement* *number*` (`-1` for all)
+
+`GroupByDate`: `GroupByDate .Pages *date_string*` Example:  
+```
+{{ range GroupByDate .Pages "2006" }}
+	<h1>{{ .Key }}</h1>
+	{{ range .Pages }}
+		<h4>{{ .Title }}</h4>
+	{{ end }}
+{{ end }}
+```
+
+`Content`: `Content .` Example:  
+```
+{{ range .Pages }}
+	<h3>{{ .Title }}</h3>
+	{{ Content . }}
+{{ end }}
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Every template receives the following set of variables:
 
 ```
 Pages       # Slice of all pages in the site
-Posts       # Slice of all posts in the site (any page with a date in the filename)
+Posts       # Slice of all posts in the site (any page with a date in the filename or front matter)
 Site        # Global site properties: Url, Title
 Page        # The current page: Title, Permalink, UrlPath, DatePublished, DateModified
 Title       # The current page title, shorthand for Page.Title
@@ -141,6 +141,27 @@ To show a list of the 5 most recent posts:
     <a href="{{ .Permalink }}">{{ .Title }}</a> <small>{{ .DatePublished.Format "Jan 02, 2006" }}</small><br />
 {{ end }}
 ```
+
+## Config
+
+`config.toml`
+
+`url`: Website base URL  
+`title`: Website title
+
+`feeds`:
+
+```
+[[feeds]]
+title = "Blog"
+path = "content/"
+length = 10 # 0 = no limit
+```
+
+## Functions
+
+`HasPrefix` - `HasPrefix *string* *prefix*`  
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Every template receives the following set of variables:
 Pages       # Slice of all pages in the site
 Posts       # Slice of all posts in the site (any page with a date in the filename or front matter)
 Site        # Global site properties: Url, Title
-Page        # The current page: Title, Permalink, UrlPath, DatePublished, DateModified
+Meta        # All keys from config.toml (for example: title, url, custom fields)
+Page        # The current page: Title, Permalink, UrlPath, DatePublished, DateModified, Meta
 Title       # The current page title, shorthand for Page.Title
 Content     # The current page's HTML content.
 Now         # Timestamp of build, instance of time.Time

--- a/example/config.toml
+++ b/example/config.toml
@@ -1,2 +1,7 @@
 url = "http://localhost:8080"
 title = "My website"
+
+[[feeds]]
+title = "blog"
+path = "content/"
+length = 10

--- a/example/config.toml
+++ b/example/config.toml
@@ -4,4 +4,5 @@ title = "My website"
 [[feeds]]
 title = "blog"
 path = "content/"
+filename = "my-feed.xml"
 length = 10

--- a/gozer.go
+++ b/gozer.go
@@ -242,6 +242,11 @@ func (s *Site) AddPageFromFile(file string) error {
 		return fmt.Errorf("%s: %s", file, err)
 	}
 
+	// Default to site title
+	if p.Title == "" {
+		p.Title = s.Title
+	}
+
 	s.Pages = append(s.Pages, p)
 
 	// every page with a date is assumed to be a blog post
@@ -553,7 +558,7 @@ func buildSite(rootPath string, configFile string) {
 			groups := make(map[string][]Page)
 			keys := make([]string, 0)
 			for _, page := range pages {
-				key := page.DateModified.Format(date)
+				key := page.DatePublished.Format(date)
 				if groups[key] == nil {
 					keys = append(keys, key)
 					groups[key] = []Page{page}

--- a/gozer.go
+++ b/gozer.go
@@ -32,6 +32,8 @@ type Site struct {
 	Pages []Page
 	Posts []Page
 
+	Feeds []Feed `toml:"feeds"`
+
 	Title   string `toml:"title"`
 	SiteUrl string `toml:"url"`
 	RootDir string
@@ -64,6 +66,12 @@ type Page struct {
 
 	// A list of tags associated with the page
 	Tags []string `toml:"tags"`
+}
+
+type Feed struct {
+	Title string `toml:"title"`
+	Path string `toml:"path"`
+	Length int `toml:"length"`
 }
 
 // parseFilename parses the URL path and optional date component from the given file path
@@ -316,7 +324,7 @@ func (s *Site) createSitemap() error {
 	return nil
 }
 
-func (s *Site) createRSSFeed() error {
+func (s *Site) createRSSFeed(name string, feedPrefix string, length int) error {
 	type Item struct {
 		Title       string `xml:"title"`
 		Link        string `xml:"link"`
@@ -343,12 +351,15 @@ func (s *Site) createRSSFeed() error {
 
 	// add 10 most recent posts to feed
 	n := len(s.Posts)
-	if n > 10 {
-		n = 10
+	if length > 0 && n > length {
+		n = length
 	}
 
 	items := make([]Item, 0, n)
 	for _, p := range s.Posts[0:n] {
+		if !strings.HasPrefix(p.Filepath, feedPrefix) {
+			continue
+		}
 		pageContent, err := p.ParseContent()
 		if err != nil {
 			log.Warn("error parsing content of %s: %s", p.Filepath, err)
@@ -376,7 +387,7 @@ func (s *Site) createRSSFeed() error {
 		},
 	}
 
-	rssFeedFilename := filepath.Join("build", "feed.xml")
+	rssFeedFilename := filepath.Join("build", name + ".xml")
 	wr, err := os.Create(rssFeedFilename)
 	if err != nil {
 		return err
@@ -563,6 +574,13 @@ func buildSite(rootPath string, configFile string) {
 			}
 			return rv
 		},
+		"Content": func(p Page) template.HTML {
+			content, err := p.ParseContent()
+			if (err != nil) {
+				return ""
+			}
+			return template.HTML(content)
+		},
 	})
 	templates, err = temp.ParseGlob(filepath.Join(rootPath, "templates/*.html"))
 	if err != nil {
@@ -605,9 +623,11 @@ func buildSite(rootPath string, configFile string) {
 		log.Warn("Error creating sitemap: %s\n", err)
 	}
 
-	// create RSS feed
-	if err := site.createRSSFeed(); err != nil {
-		log.Warn("Error creating RSS feed: %s\n", err)
+	// create RSS feeds
+	for _, feed := range site.Feeds {
+		if err := site.createRSSFeed(feed.Title, feed.Path, feed.Length); err != nil {
+			log.Warn("Error creating RSS feed: %s\n", err)
+		}
 	}
 
 	// static files

--- a/gozer.go
+++ b/gozer.go
@@ -32,7 +32,7 @@ type Site struct {
 	Pages []Page
 	Posts []Page
 
-	Feeds []Feed `toml:"feeds"`
+	Feeds []FeedDef `toml:"feeds"`
 
 	Title   string `toml:"title"`
 	SiteUrl string `toml:"url"`
@@ -68,9 +68,10 @@ type Page struct {
 	Tags []string `toml:"tags"`
 }
 
-type Feed struct {
+type FeedDef struct {
 	Title string `toml:"title"`
 	Path string `toml:"path"`
+	Filename string `toml:"filename,omitempty"`
 	Length int `toml:"length"`
 }
 
@@ -329,7 +330,7 @@ func (s *Site) createSitemap() error {
 	return nil
 }
 
-func (s *Site) createRSSFeed(name string, feedPrefix string, length int) error {
+func (s *Site) createRSSFeed(feedDef FeedDef) error {
 	type Item struct {
 		Title       string `xml:"title"`
 		Link        string `xml:"link"`
@@ -356,13 +357,13 @@ func (s *Site) createRSSFeed(name string, feedPrefix string, length int) error {
 
 	// add 10 most recent posts to feed
 	n := len(s.Posts)
-	if length > 0 && n > length {
-		n = length
+	if feedDef.Length > 0 && n > feedDef.Length {
+		n = feedDef.Length
 	}
 
 	items := make([]Item, 0, n)
 	for _, p := range s.Posts[0:n] {
-		if !strings.HasPrefix(p.Filepath, feedPrefix) {
+		if !strings.HasPrefix(p.Filepath, feedDef.Path) {
 			continue
 		}
 		pageContent, err := p.ParseContent()
@@ -392,7 +393,7 @@ func (s *Site) createRSSFeed(name string, feedPrefix string, length int) error {
 		},
 	}
 
-	rssFeedFilename := filepath.Join("build", name + ".xml")
+	rssFeedFilename := filepath.Join("build", feedDef.Filename)
 	wr, err := os.Create(rssFeedFilename)
 	if err != nil {
 		return err
@@ -427,6 +428,30 @@ func parseConfig(s *Site, file string) error {
 	// ensure site url has trailing slash
 	if !strings.HasSuffix(s.SiteUrl, "/") {
 		s.SiteUrl += "/"
+	}
+
+	pathCleaner := strings.NewReplacer(
+		"\"", "",
+		"\\", "",
+		"/", "",
+		"?", "",
+		":", "",
+		"*", "",
+		"<", "",
+		">", "",
+		"|", "",
+		" ", "-",
+	)
+
+	// Assign filenames to feeds
+	for i := range s.Feeds {
+		fmt.Printf("A:%s:B\n", s.Feeds[i].Filename);
+		if s.Feeds[i].Filename == "" {
+			s.Feeds[i].Filename = strings.ToLower(pathCleaner.Replace(s.Feeds[i].Title))
+		}
+		if !strings.HasSuffix(s.Feeds[i].Filename, ".xml") {
+			s.Feeds[i].Filename += ".xml"
+		}
 	}
 
 	return nil
@@ -630,7 +655,7 @@ func buildSite(rootPath string, configFile string) {
 
 	// create RSS feeds
 	for _, feed := range site.Feeds {
-		if err := site.createRSSFeed(feed.Title, feed.Path, feed.Length); err != nil {
+		if err := site.createRSSFeed(feed); err != nil {
 			log.Warn("Error creating RSS feed: %s\n", err)
 		}
 	}

--- a/gozer.go
+++ b/gozer.go
@@ -583,7 +583,7 @@ func buildSite(rootPath string, configFile string) {
 			groups := make(map[string][]Page)
 			keys := make([]string, 0)
 			for _, page := range pages {
-				key := page.DatePublished.Format(date)
+				key := page.DateModified.Format(date)
 				if groups[key] == nil {
 					keys = append(keys, key)
 					groups[key] = []Page{page}

--- a/gozer.go
+++ b/gozer.go
@@ -47,7 +47,7 @@ type Page struct {
 	Template string
 
 	// Time this page was published (parsed from file name).
-	DatePublished time.Time
+	DatePublished time.Time `toml:"datepublished"`
 
 	// Time this page was last modified (from filesystem).
 	DateModified time.Time

--- a/gozer.go
+++ b/gozer.go
@@ -37,6 +37,8 @@ type Site struct {
 	Title   string `toml:"title"`
 	SiteUrl string `toml:"url"`
 	RootDir string
+	Meta map[string]any `toml:"-"`
+	Attrs map[string]any `toml:"-"`
 }
 
 type Page struct {
@@ -63,6 +65,10 @@ type Page struct {
 
 	// Whether the page should be published or not
 	Draft bool `toml:"draft"`
+
+	Meta map[string]any `toml:"-"`
+
+	Attrs map[string]any `toml:"-"`
 
 	// A list of tags associated with the page
 	Tags []string `toml:"tags"`
@@ -126,7 +132,19 @@ func parseFrontMatter(p *Page) error {
 		return fmt.Errorf("missing closing front-matter identifier in %s", p.Filepath)
 	}
 
-	return toml.Unmarshal(buf[:pos], p)
+	meta := make(map[string]any)
+
+	if err := toml.Unmarshal(buf[:pos], p); err != nil {
+		return err
+	}
+
+	if err := toml.Unmarshal(buf[:pos], &meta); err != nil {
+		return err
+	}
+
+	p.Meta = meta
+	p.Attrs = p.Meta
+	return nil
 }
 
 func (p *Page) ParseContent() (string, error) {
@@ -204,6 +222,8 @@ func (s *Site) buildPage(p *Page) error {
 			"Url":   s.SiteUrl,
 			"Title": s.Title,
 		},
+		"Meta":  s.Meta,
+		"Attrs": s.Meta,
 
 		// If the page is a post, it may have a next and previous post
 		// These may also be nil
@@ -424,6 +444,15 @@ func parseConfig(s *Site, file string) error {
 	if err != nil {
 		return err
 	}
+
+	meta := make(map[string]any)
+
+	if _, err := toml.DecodeFile(file, &meta); err != nil {
+		return err
+	}
+
+	s.Meta = meta
+	s.Attrs = s.Meta
 
 	// ensure site url has trailing slash
 	if !strings.HasSuffix(s.SiteUrl, "/") {


### PR DESCRIPTION
I tweaked a few things in gozer for my usecase (personal website, blog and devlog all in one). Not sure if these changes are desired in the main repo.

Changes below:

1) Allowing the user to define different RSS feeds, in config.toml. This could be useful for example if you want a seperate feed for a blog, and a devlog. Specified by the root directory of all content for the given feed (e.g. `content/blog` or `content/devlog` will produce different feeds)

2) Adding `Content` function that can be used to get the content of a page when iterating through them. e.g.:  
```
{{ range .Pages }}
  {{ Content . }}
{{ end }}
```   
This would also be useful for a devlog, where the content of multiple files can be printed out on one page

3) Minor additions to README, as well as documenting changes
    - Added functions
    - datepublished in front-matter as alternative to in filename
    - Added config section including new `feeds` section

4) Updated to `example/config.toml` to show new `feeds` syntax

5) Changes to how Site.Title is used. Made it the default if no Page title is given, and now using seperate title for RSS feeds

~Not ready to be merged yet, just wanted to open the pull request, need to finish off README updates.~ No worries if not all of this functionality is desired. Can also split it up into multiple pull requests if that would be better.

I really like gozer, it strikes the perfect balance between minimal and functional, perfect for my usecase