### PR TITLE
fix: add @latest to go install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The [example](example/) directory contains a barebones example of a Gozer site.
 You can install Gozer by first installing a Go compiler and then running:
 
 ```sh
-go install github.com/dannyvankooten/gozer
+go install github.com/dannyvankooten/gozer@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Fixes the install command in README.md to use `@latest` suffix.

## Why

Without `@latest`, `go install` fails when run outside a module context:

```sh
$ go install github.com/dannyvankooten/gozer
go: 'go install' requires a version when current directory is not in a module
        Try 'go install github.com/dannyvankooten/gozer@latest' to install the latest version
```

Adding `@latest` makes the command work in any context.

## Changes

- README.md line 17: `go install github.com/dannyvankooten/gozer` → `go install github.com/dannyvankooten/gozer@latest`

Fixes #10