### PR TITLE
Merge back a bunch of changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ type Page struct {
     // Template this page uses for rendering. Defaults to "default.html".
     Template      string
 
-    // Time this page was published (parsed from file name).
-    DatePublished time.Time
+    // Time this page was published (parsed from file name or front matter).
+    DatePublished time.Time      `toml:"datepublished"`
 
     // Time this page was last modified on the filesystem.
     DateModified  time.Time
@@ -140,10 +140,10 @@ type Page struct {
     Filepath      string
 
     // Parsed front matter values, keyed by TOML key
-    Meta          map[string]any
+    Meta          map[string]any `toml:"-"`
 
     // Deprecated: use Meta.
-    Attrs         map[string]any
+    Attrs         map[string]any `toml:"-"`
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Every template receives the following set of variables:
 
 ```
 Pages       # Slice of all pages in the site
-Posts       # Slice of all posts in the site (any page with a date in the filename)
+Posts       # Slice of all posts in the site (any page with a date in the filename or front matter)
 Site        # Global site properties: Url, Title
 Meta        # All keys from config.toml (for example: title, url, custom fields)
 Page        # The current page: Title, Permalink, UrlPath, DatePublished, DateModified, Meta
@@ -153,6 +153,57 @@ To show a list of the 5 most recent posts:
 {{ range (slice .Posts 0 5) }}
     <a href="{{ .Permalink }}">{{ .Title }}</a> <small>{{ .DatePublished.Format "Jan 02, 2006" }}</small><br />
 {{ end }}
+```
+
+## Config
+
+Options in `config.toml`:
+
+`url`: Website base URL
+
+`title`: Website title (used if no page title given)
+
+`feeds`:  
+```
+[[feeds]]
+title = "Blog"
+path = "content/"
+filename = "myfeed.xml"
+favicon = "favicon.png" # optional, relative to base URL
+length = 10 # 0 = no limit
+```
+
+## Functions
+
+`HasPrefix`: `HasPrefix *string* *prefix*`
+
+`HasSuffix`: `HasSuffix *string* *suffix*`
+
+`Contains`: `Contains *string* *sub_string*`
+
+`Replace`: `Replace *string* *target* *replacement* *number*` (`-1` for all)
+
+`GroupByDate`: `GroupByDate .Pages *date_string*` Example:  
+```
+{{ range GroupByDate .Pages "2006" }}
+	<h1>{{ .Key }}</h1>
+	{{ range .Pages }}
+		<h4>{{ .Title }}</h4>
+	{{ end }}
+{{ end }}
+```
+
+`Content`: `Content .` Example:  
+```
+{{ range .Pages }}
+	<h3>{{ .Title }}</h3>
+	{{ Content . }}
+{{ end }}
+```
+
+`AsTime`: `AsTime "*date_format*" *date_variable*` Example:  
+```
+{{ (AsTime "2006-01-02" .Attrs.MyCustomDate ).Format "2 Jan 2006" }}
 ```
 
 ## Contributing

--- a/example/config.toml
+++ b/example/config.toml
@@ -4,3 +4,16 @@ title = "My website"
 key1 = 1
 key2 = "two"
 # key3 = 20250822T11:08:00Z
+
+[[feeds]]
+title = "My Feed"
+path = "content"
+filename = "feed.xml"
+favicon = "favicon.ico"
+length = 0 # Unlimited
+
+[[feeds]]
+title = "Just my blog"
+path = "content/blog" # Must be a sub-dir of content
+filename = "blog.xml"
+length = 10

--- a/example/content/blog/2023-11-02-hello-blog.md
+++ b/example/content/blog/2023-11-02-hello-blog.md
@@ -1,0 +1,5 @@
++++
+title = "Hello, Blog!"
++++
+
+This is an actual blog post that will be in `/blog/` of the website!

--- a/gozer.go
+++ b/gozer.go
@@ -77,6 +77,7 @@ type FeedDef struct {
 	Title string `toml:"title"`
 	Path string `toml:"path"`
 	Filename string `toml:"filename"`
+	Favicon string `toml:"favicon,omitempty"`
 	Length int `toml:"length"`
 }
 
@@ -351,10 +352,17 @@ func (s *Site) createRSSFeed(feedDef FeedDef) error {
 		GUID        string `xml:"guid"`
 	}
 
+	type Image struct {
+		Title         string `xml:"title",`
+		Link          string `xml:"link"`
+		URL           string `xml:"url"`
+	}
+
 	type Channel struct {
 		Title         string `xml:"title"`
 		Link          string `xml:"link"`
 		Description   string `xml:"description"`
+		Image         *Image `xml:"image,omitzero"`
 		Generator     string `xml:"generator"`
 		LastBuildDate string `xml:"lastBuildDate"`
 		Items         []Item `xml:"item"`
@@ -393,12 +401,25 @@ func (s *Site) createRSSFeed(feedDef FeedDef) error {
 		})
 	}
 
+	// image is using a pointer to allow "omitzero" in the xml parsing to work
+	image := &Image{}
+	if feedDef.Favicon != "" {
+		image = &Image{
+			Title: feedDef.Title,
+			Link:  s.SiteUrl,
+			URL:   s.SiteUrl + feedDef.Favicon,
+		}
+	} else {
+		image = nil
+	}
+
 	feed := Feed{
 		Version: "2.0",
 		Atom:    "http://www.w3.org/2005/Atom",
 		Channel: Channel{
 			Title:         feedDef.Title,
 			Link:          s.SiteUrl,
+			Image:         image,
 			Generator:     "Gozer",
 			LastBuildDate: time.Now().Format(time.RFC1123Z),
 			Items:         items,
@@ -558,7 +579,7 @@ func createDirectoryStructure(rootPath string) error {
 		Name    string
 		Content []byte
 	}{
-		{"config.toml", []byte("url = \"http://localhost:8080\"\ntitle = \"My website\"\n\n[[feeds]]\ntitle = \"My website feed\"\npath = \"content/\"\nfilename = \"feed.xml\"\nlength = 10\n")},
+		{"config.toml", []byte("url = \"http://localhost:8080\"\ntitle = \"My website\"\n\n[[feeds]]\ntitle = \"My website feed\"\npath = \"content/\"\nfilename = \"feed.xml\"\nfavicon = \"favicon.png\"\nlength = 10\n")},
 		{"templates/default.html", []byte("<!DOCTYPE html>\n<head>\n\t<title>{{ .Title }}</title>\n</head>\n<body>\n{{ .Content }}\n</body>\n</html>")},
 		{"content/index.md", []byte("+++\ntitle = \"Gozer!\"\n+++\n\nWelcome to my website.\n")},
 		// TODO djot does not (yet) support front matter, and godjot does not parse it. Once the front-matter syntax is settled, this should change. +djot +frontmatter

--- a/gozer.go
+++ b/gozer.go
@@ -102,7 +102,7 @@ func parseFrontMatter(p *Page) error {
 	}
 	defer fh.Close()
 
-	buf := make([]byte, 1024)
+	buf := make([]byte, 4096)
 	n, err := fh.Read(buf)
 	if err != nil {
 		return err

--- a/gozer.go
+++ b/gozer.go
@@ -32,6 +32,8 @@ type Site struct {
 	Pages []Page
 	Posts []Page
 
+	Feeds []FeedDef `toml:"feeds"`
+
 	Title   string `toml:"title"`
 	SiteUrl string `toml:"url"`
 	RootDir string
@@ -69,6 +71,13 @@ type Page struct {
 
 	// Deprecated: use Meta.
 	Attrs map[string]any `toml:"-"`
+}
+
+type FeedDef struct {
+	Title string `toml:"title"`
+	Path string `toml:"path"`
+	Filename string `toml:"filename"`
+	Length int `toml:"length"`
 }
 
 // parseFilename parses the URL path and optional date component from the given file path
@@ -333,7 +342,7 @@ func (s *Site) createSitemap() error {
 	return nil
 }
 
-func (s *Site) createRSSFeed() error {
+func (s *Site) createRSSFeed(feedDef FeedDef) error {
 	type Item struct {
 		Title       string `xml:"title"`
 		Link        string `xml:"link"`
@@ -358,14 +367,17 @@ func (s *Site) createRSSFeed() error {
 		Channel Channel  `xml:"channel"`
 	}
 
-	// add 10 most recent posts to feed
+	// Add specified number of posts to feed
 	n := len(s.Posts)
-	if n > 10 {
-		n = 10
+	if feedDef.Length > 0 && feedDef.Length < n {
+		n = feedDef.Length
 	}
 
 	items := make([]Item, 0, n)
 	for _, p := range s.Posts[0:n] {
+		if !strings.HasPrefix(p.Filepath, s.RootDir+feedDef.Path) {
+			continue
+		}
 		pageContent, err := p.ParseContent()
 		if err != nil {
 			log.Warn("error parsing content of %s: %s", p.Filepath, err)
@@ -385,7 +397,7 @@ func (s *Site) createRSSFeed() error {
 		Version: "2.0",
 		Atom:    "http://www.w3.org/2005/Atom",
 		Channel: Channel{
-			Title:         s.Title,
+			Title:         feedDef.Title,
 			Link:          s.SiteUrl,
 			Generator:     "Gozer",
 			LastBuildDate: time.Now().Format(time.RFC1123Z),
@@ -393,7 +405,7 @@ func (s *Site) createRSSFeed() error {
 		},
 	}
 
-	rssFeedFilename := filepath.Join("build", "feed.xml")
+	rssFeedFilename := filepath.Join("build", feedDef.Filename)
 	wr, err := os.Create(rssFeedFilename)
 	if err != nil {
 		return err
@@ -436,6 +448,17 @@ func parseConfig(s *Site, file string) error {
 	// ensure site url has trailing slash
 	if !strings.HasSuffix(s.SiteUrl, "/") {
 		s.SiteUrl += "/"
+	}
+
+	// Process feed filenames
+	for i := range s.Feeds {
+		if s.Feeds[i].Filename == "" {
+			log.Fatal("Feed \"%s\" has no filename configured in config.toml", s.Feeds[i].Title)
+		}
+		if !strings.HasSuffix(s.Feeds[i].Filename, ".xml") {
+			s.Feeds[i].Filename += ".xml"
+		}
+		fmt.Printf("Feed found: \"%s\"\n", s.Feeds[i].Filename);
 	}
 
 	return nil
@@ -535,7 +558,7 @@ func createDirectoryStructure(rootPath string) error {
 		Name    string
 		Content []byte
 	}{
-		{"config.toml", []byte("url = \"http://localhost:8080\"\ntitle = \"My website\"\n")},
+		{"config.toml", []byte("url = \"http://localhost:8080\"\ntitle = \"My website\"\n\n[[feeds]]\ntitle = \"My website feed\"\npath = \"content/\"\nfilename = \"feed.xml\"\nlength = 10\n")},
 		{"templates/default.html", []byte("<!DOCTYPE html>\n<head>\n\t<title>{{ .Title }}</title>\n</head>\n<body>\n{{ .Content }}\n</body>\n</html>")},
 		{"content/index.md", []byte("+++\ntitle = \"Gozer!\"\n+++\n\nWelcome to my website.\n")},
 		// TODO djot does not (yet) support front matter, and godjot does not parse it. Once the front-matter syntax is settled, this should change. +djot +frontmatter
@@ -646,9 +669,11 @@ func buildSite(rootPath string, configFile string) {
 		log.Warn("Error creating sitemap: %s\n", err)
 	}
 
-	// create RSS feed
-	if err := site.createRSSFeed(); err != nil {
-		log.Warn("Error creating RSS feed: %s\n", err)
+	// create RSS feeds
+	for _, feed := range site.Feeds {
+		if err := site.createRSSFeed(feed); err != nil {
+			log.Warn("Error creating RSS feed: %s\n", err)
+		}
 	}
 
 	// static files

--- a/gozer.go
+++ b/gozer.go
@@ -591,6 +591,14 @@ func buildSite(rootPath string, configFile string) {
 			}
 			return rv
 		},
+		"Content": func(p Page) template.HTML {
+			content, err := p.ParseContent()
+			if (err != nil) {
+				return ""
+			}
+			return template.HTML(content)
+		},
+		"AsTime": time.Parse,
 	})
 	templates, err = temp.ParseGlob(filepath.Join(rootPath, "templates/*.html"))
 	if err != nil {

--- a/gozer.go
+++ b/gozer.go
@@ -49,8 +49,8 @@ type Page struct {
 	// Template this page uses for rendering. Defaults to "default.html".
 	Template string
 
-	// Time this page was published (parsed from file name).
-	DatePublished time.Time
+	// Time this page was published (parsed from file name or front matter).
+	DatePublished time.Time `toml:"datepublished"`
 
 	// Time this page was last modified (from filesystem).
 	DateModified time.Time
@@ -64,6 +64,7 @@ type Page struct {
 	// Path to source file for this page, relative to content root
 	Filepath string
 
+	// Parsed front matter values, keyed by TOML key
 	Meta map[string]any `toml:"-"`
 
 	// Deprecated: use Meta.


### PR DESCRIPTION
Here are the changes, hopefully neatly enough done.

[Update README and example](https://github.com/CactiChameleon9/gozer/commit/e22fc984e840227e78782c4b99ee59bc30cba18c)
[Add favicon image support to RSS feeds](https://github.com/CactiChameleon9/gozer/commit/1468b801a29cdbdbdcc43c0155ff38901174be98)
[Allow for multiple feeds defined in config.toml](https://github.com/CactiChameleon9/gozer/commit/6b611426487bfe5319f19c2a9203c46ebf63fbe6) EDIT: Amended
[Add Content and AsTime functions to the template processing](https://github.com/CactiChameleon9/gozer/commit/7f56ecb9c6c48b538c5fbade336d388beb6d4b0b)
[Increase front matter max size, for use of meta](https://github.com/CactiChameleon9/gozer/commit/4ed7bed6189631e445d43c1dad3be65b5297d0f7)
[Make DatePublished editable in front matter; cleanup Page docs](https://github.com/CactiChameleon9/gozer/commit/c70ec9d1430cf8cb6196302cf23db5d886357404)

Any critiques would be greatly appreciated.

A decent amount of this is heavily based on the work by @regexghost in #7, but I did change the following:
- Removed optional feed filename, decided the extra filtering function wasn't worth the code bloat. Also, people ideally should know what their RSS file is called (not just from the logs)
- Removed the autonaming of posts to the server name. An empty name is a sign that something isn't ready or needs filling in, feels strange to tamper with it.

Of course I also included:
- Favicon support for the feeds
- Further improved docs/example/defaults
- New AsTime gotemplate function


Hope this is all okay
